### PR TITLE
Rewritten GetServers code to prevent index related errors, cleaned code

### DIFF
--- a/ServerHub/Handlers/ServerListener.cs
+++ b/ServerHub/Handlers/ServerListener.cs
@@ -161,8 +161,12 @@ namespace ServerHub.Handlers {
         }
 
         List<Data> GetServers(int Offset, int count=6) {
-            var index = (count - 1) * Offset;
-            return ConnectedClients.Select(o => o.Data).Where(o => o.ID != -1).ToList().GetRange(index, count + index >= ConnectedClients.Count(o => o.Data.ID != -1) ? Math.Clamp(ConnectedClients.Count(o => o.Data.ID != -1) - index, 0, 6) : count + index);
+            var index = count * Offset;
+            var connectedClients = ConnectedClients
+                .Where(cc => cc.Data.ID != -1)
+                .Select(cc => cc.Data);
+
+            return connectedClients.Skip(index).Take(count).ToList();
         }
 
         public void Stop() {


### PR DESCRIPTION
I've re-written the GetServers code, as this was causing exceptions previously.
Also the code seemed (unless I am unaware of something) overly complex for no reason.
Due to the apparent preferred style of LINQ however I've written the code to use LINQ & also make use of variables to stop re-iterating over the whole list every time for count etc.