### PR TITLE
WebSockets Data Feed

### DIFF
--- a/BeatSaberMultiplayerServer/BeatSaberMultiplayerServer.csproj
+++ b/BeatSaberMultiplayerServer/BeatSaberMultiplayerServer.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NVorbis" Version="0.8.5" />
+    <PackageReference Include="WebSocketSharp" Version="1.0.3-rc11" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerCommons\ServerCommons.csproj" />

--- a/BeatSaberMultiplayerServer/Misc/Settings.cs
+++ b/BeatSaberMultiplayerServer/Misc/Settings.cs
@@ -12,6 +12,8 @@ namespace BeatSaberMultiplayerServer.Misc {
         public class ServerSettings {
             private string _ip;
             private int _port;
+            private int _wsport;
+            private bool _wsenabled;
             private string _serverName;
             private string _serverHubIP;
             private int _serverHubPort;
@@ -50,6 +52,34 @@ namespace BeatSaberMultiplayerServer.Misc {
                 set
                 {
                     _port = value;
+                    MarkDirty();
+                }
+            }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
+            public int WSPort
+            {
+                get => _wsport;
+                set
+                {
+                    _wsport = value;
+                    MarkDirty();
+                }
+            }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
+            public bool WSEnabled
+            {
+                get => _wsenabled;
+                set
+                {
+                    _wsenabled = value;
                     MarkDirty();
                 }
             }
@@ -145,6 +175,8 @@ namespace BeatSaberMultiplayerServer.Misc {
             public ServerSettings(Action markDirty) {
                 MarkDirty = markDirty;
                 _port = 3701;
+                _wsport = 3702;
+                _wsenabled = false;
                 _serverName = "New Server";
                 _serverHubIP = "beatsaber.jaddie.co.uk";
                 _serverHubPort = 3700;

--- a/BeatSaberMultiplayerServer/ServerMain.cs
+++ b/BeatSaberMultiplayerServer/ServerMain.cs
@@ -366,7 +366,7 @@ namespace BeatSaberMultiplayerServer
                                         .OrderByDescending(x => x.playerInfo.playerScore)
                                         .Select(x => JsonConvert.SerializeObject(x.playerInfo))).ToArray(),
                                     _selectedSongDuration: availableSongs[currentSongIndex].duration.TotalSeconds,
-                                    _selectedSongPlayTime: playTime.TotalSeconds)));
+                                    _selectedSongPlayTime: playTime.TotalSeconds)), wss);
                                 sendTimer = 0f;
                             }
 

--- a/BeatSaberMultiplayerServer/ServerMain.cs
+++ b/BeatSaberMultiplayerServer/ServerMain.cs
@@ -434,6 +434,21 @@ namespace BeatSaberMultiplayerServer
             }
         }
 
+        static void SendToAllClients(string message, WebSocketServer wss, bool retryOnError = false)
+        {
+            try
+            {
+                clients.Where(x => x != null && (x.state == ClientState.Connected || x.state == ClientState.Playing))
+                    .AsParallel().ForAll(x => { x.sendQueue.Enqueue(message); });
+
+                wss.WebSocketServices["/"].Sessions.Broadcast(message);
+            }
+            catch (Exception e)
+            {
+                Logger.Instance.Exception("Can't send message to all clients! Exception: " + e);
+            }
+        }
+
         void AcceptClientThread()
         {
             while (ListenerThread.IsAlive)

--- a/BeatSaberMultiplayerServer/ServerMain.cs
+++ b/BeatSaberMultiplayerServer/ServerMain.cs
@@ -61,11 +61,6 @@ namespace BeatSaberMultiplayerServer
             Console.Title = string.Format(TitleFormat, Settings.Instance.Server.ServerName, 0);
             Logger.Instance.Log($"Beat Saber Multiplayer Server v{Assembly.GetEntryAssembly().GetName().Version}");
 
-            // WEBSOCKET CODE
-            wss = new WebSocketServer(1337);
-            wss.AddWebSocketService<Broadcast>("/");
-            wss.Start();
-
             if (args.Length > 0)
             {
                 try
@@ -96,6 +91,14 @@ namespace BeatSaberMultiplayerServer
 
             ServerLoopThread = new Thread(ServerLoop) { IsBackground = true };
             ServerLoopThread.Start();
+
+            if (Settings.Instance.Server.WSEnabled)
+            {
+                Logger.Instance.Log($"WebSocket Server started @ {Settings.Instance.Server.IP}:{Settings.Instance.Server.WSPort}");
+                wss = new WebSocketServer(Settings.Instance.Server.WSPort);
+                wss.AddWebSocketService<Broadcast>("/");
+                wss.Start();
+            }
 
             try
             {

--- a/BeatSaberMultiplayerServer/ServerMain.cs
+++ b/BeatSaberMultiplayerServer/ServerMain.cs
@@ -443,8 +443,11 @@ namespace BeatSaberMultiplayerServer
             {
                 clients.Where(x => x != null && (x.state == ClientState.Connected || x.state == ClientState.Playing))
                     .AsParallel().ForAll(x => { x.sendQueue.Enqueue(message); });
-
-                wss.WebSocketServices["/"].Sessions.Broadcast(message);
+                
+                if (wss != null)
+                {
+                    wss.WebSocketServices["/"].Sessions.Broadcast(message);
+                }
             }
             catch (Exception e)
             {

--- a/BeatSaberMultiplayerServer/ServerMain.cs
+++ b/BeatSaberMultiplayerServer/ServerMain.cs
@@ -14,9 +14,21 @@ using System.Reflection;
 using System.Threading;
 using Math = ServerCommons.Misc.Math;
 using Settings = BeatSaberMultiplayerServer.Misc.Settings;
+using Logger = ServerCommons.Misc.Logger;
+using WebSocketSharp;
+using WebSocketSharp.Server;
 
 namespace BeatSaberMultiplayerServer
 {
+    public class Broadcast : WebSocketBehavior
+    {
+        protected override void OnOpen()
+        {
+            base.OnOpen();
+            Logger.Instance.Log("WebSocket Client Connected!");
+        }
+    }
+
     class ServerMain
     {
         static TcpListener _listener;
@@ -40,12 +52,19 @@ namespace BeatSaberMultiplayerServer
         private Thread ListenerThread { get; set; }
         private Thread ServerLoopThread { get; set; }
 
+        public WebSocketServer wss;
+
         static void Main(string[] args) => new ServerMain().Start(args);
 
         public void Start(string[] args)
         {
             Console.Title = string.Format(TitleFormat, Settings.Instance.Server.ServerName, 0);
             Logger.Instance.Log($"Beat Saber Multiplayer Server v{Assembly.GetEntryAssembly().GetName().Version}");
+
+            // WEBSOCKET CODE
+            wss = new WebSocketServer(1337);
+            wss.AddWebSocketService<Broadcast>("/");
+            wss.Start();
 
             if (args.Length > 0)
             {


### PR DESCRIPTION
This pull request monkey-patches in support for a websocket server. This allows external clients to be able to read the data stream without being connected in game.

Practical uses for this would be a script similar to the one used in the Beat Saber invitational, which has a live updating score for all players in OBS.

The WebSocket server is disabled by default and requires enabling in `Settings.json`