### PR TITLE
Minor Log Improvements

### DIFF
--- a/ServerHub/Misc/Extensions.cs
+++ b/ServerHub/Misc/Extensions.cs
@@ -7,7 +7,7 @@ namespace System.Linq {
         public static ConsoleColor GetColour(this Logger.LogMessage message) {
             switch (message.Level) {
                 case Logger.LoggerLevel.Info:
-                    return ConsoleColor.Blue;
+                    return ConsoleColor.Green;
                 case Logger.LoggerLevel.Warning:
                     return ConsoleColor.Magenta;
                 case Logger.LoggerLevel.Exception:

--- a/ServerHub/Misc/Logger.cs
+++ b/ServerHub/Misc/Logger.cs
@@ -85,6 +85,7 @@ namespace ServerHub.Misc {
             Console.WriteLine(msg.Message);
             if (msg.PrintToLog)
                 LogWriter.WriteLine(msg.Message);
+            Console.ResetColor();
         }
 
         FileInfo GetPath() {

--- a/ServerHub/Misc/Logger.cs
+++ b/ServerHub/Misc/Logger.cs
@@ -51,28 +51,28 @@ namespace ServerHub.Misc {
 
         public void Log(object msg, bool hideHeader = false) {
             if(!hideHeader)
-                PrintLogMessage(new LogMessage($"[LOG @ {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Info));
+                PrintLogMessage(new LogMessage($"[LOG       -- {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Info));
             else
                 PrintLogMessage(new LogMessage($"{msg}", LoggerLevel.Info, false));
         }
 
         public void Error(object msg, bool hideHeader = false) {
             if (!hideHeader)
-                PrintLogMessage(new LogMessage($"[ERROR @ {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Error));
+                PrintLogMessage(new LogMessage($"[ERROR     -- {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Error));
             else
                 PrintLogMessage(new LogMessage($"{msg}", LoggerLevel.Error, false));
         }
 
         public void Exception(object msg, bool hideHeader = false) {
             if (!hideHeader)
-                PrintLogMessage(new LogMessage($"[EXCEPTION @ {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Exception));
+                PrintLogMessage(new LogMessage($"[EXCEPTION -- {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Exception));
             else
                 PrintLogMessage(new LogMessage($"{msg}", LoggerLevel.Exception, false));
         }
 
         public void Warning(object msg, bool hideHeader = false) {
             if (!hideHeader)
-                PrintLogMessage(new LogMessage($"[Warning @ {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Warning));
+                PrintLogMessage(new LogMessage($"[WARNING   -- {DateTime.Now:HH:mm:ss}] {msg}", LoggerLevel.Warning));
             else
                 PrintLogMessage(new LogMessage($"{msg}", LoggerLevel.Warning, false));
         }


### PR DESCRIPTION
* Resets console colour after printing
  This means exiting with a `CTRL+C` won't mess up terminal colours
* Aligned and slightly reformatted log headers
  Log levels are now padded with spaces so that the timestamps and text line up nicely
* Changed INFO level from blue to green
  The default console colours on Windows made blue on a black background hard on the eyes
  Green seems nicer and more friendly for information