### PR TITLE
Tournament Mode

### DIFF
--- a/ServerHub/Hub/Program.cs
+++ b/ServerHub/Hub/Program.cs
@@ -153,8 +153,8 @@ namespace ServerHub.Hub
                 RoomSettings settings = new RoomSettings()
                 {
                     Name = $"Tournament Room {i + 1}",
-                    UsePassword = false,
-                    Password = "",
+                    UsePassword = Settings.Instance.TournamentMode.Password != "",
+                    Password = Settings.Instance.TournamentMode.Password,
                     NoFail = true,
                     MaxPlayers = 0,
                     SelectionType = Data.SongSelectionType.Manual,

--- a/ServerHub/Hub/Program.cs
+++ b/ServerHub/Hub/Program.cs
@@ -148,7 +148,7 @@ namespace ServerHub.Hub
         {
             for (int i = 0; i < Settings.Instance.TournamentMode.Rooms; i++)
             {
-                List<SongInfo> songs = Settings.Instance.TournamentMode.SongHashes.ConvertAll(x => new SongInfo() { levelId = x.ToUpper(), songName = "" });
+                List<SongInfo> songs = BeatSaver.ConvertSongIDs(Settings.Instance.TournamentMode.SongIDs);
 
                 RoomSettings settings = new RoomSettings()
                 {

--- a/ServerHub/Hub/Program.cs
+++ b/ServerHub/Hub/Program.cs
@@ -146,8 +146,6 @@ namespace ServerHub.Hub
 #endif
         private void CreateTournamentRooms()
         {
-            Console.WriteLine(Settings.Instance.TournamentMode.Rooms);
-
             for (int i = 0; i < Settings.Instance.TournamentMode.Rooms; i++)
             {
                 List<SongInfo> songs = Settings.Instance.TournamentMode.SongHashes.ConvertAll(x => new SongInfo() { levelId = x.ToUpper(), songName = "" });

--- a/ServerHub/Hub/Program.cs
+++ b/ServerHub/Hub/Program.cs
@@ -85,6 +85,9 @@ namespace ServerHub.Hub
 
             HubListener.Start();
 
+            if (Settings.Instance.TournamentMode.Enabled)
+                CreateTournamentRooms();
+
             Logger.Instance.Warning($"Use [Help] to display commands");
             Logger.Instance.Warning($"Use [Quit] to exit");
             
@@ -97,7 +100,6 @@ namespace ServerHub.Hub
 
                 Logger.Instance.Log(ProcessCommand(parsedArgs[0], parsedArgs.Skip(1).ToArray()));
             }
-            
         }
 
 #if DEBUG
@@ -142,6 +144,32 @@ namespace ServerHub.Hub
             }
         }
 #endif
+        private void CreateTournamentRooms()
+        {
+            Console.WriteLine(Settings.Instance.TournamentMode.Rooms);
+
+            for (int i = 0; i < Settings.Instance.TournamentMode.Rooms; i++)
+            {
+                List<SongInfo> songs = Settings.Instance.TournamentMode.SongHashes.ConvertAll(x => new SongInfo() { levelId = x.ToUpper(), songName = "" });
+
+                RoomSettings settings = new RoomSettings()
+                {
+                    Name = $"Tournament Room {i + 1}",
+                    UsePassword = false,
+                    Password = "",
+                    NoFail = true,
+                    MaxPlayers = 0,
+                    SelectionType = Data.SongSelectionType.Manual,
+                    AvailableSongs = songs,
+                };
+
+                PlayerInfo host = new PlayerInfo("server", 76561198047255564);
+                uint id = RoomsController.CreateRoom(settings, host);
+
+                Logger.Instance.Log("Created tournament room with ID " + id);
+            }
+        }
+
         string ProcessCommand(string comName, string[] comArgs)
         {
             switch (comName.ToLower())

--- a/ServerHub/Misc/BeatSaver.cs
+++ b/ServerHub/Misc/BeatSaver.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Net;
+using System.Linq;
+using ServerHub.Data;
+using Newtonsoft.Json;
+
+namespace ServerHub.Misc
+{
+    static class BeatSaver
+    {
+        static readonly string BeatSaverAPI = "https://beatsaver.com/api/songs/detail";
+
+        public class JsonResponse
+        {
+            public Song Song { get; set; }
+        }
+
+        public class Song
+        {
+            public string Key { get; set; }
+            public string Name { get; set; }
+            public string HashMD5 { get; set; }
+        }
+
+        public static Song FetchByID (string id)
+        {
+            using (WebClient w = new WebClient())
+            {
+                try
+                {
+                    string response = w.DownloadString($"{BeatSaverAPI}/{id}");
+                    JsonResponse json = JsonConvert.DeserializeObject<JsonResponse>(response);
+                    return json.Song;
+                    
+                }
+                catch (Exception e)
+                {
+#if DEBUG
+                    Logger.Instance.Exception(e);
+#endif
+                    return null;
+                }
+            }
+        }
+
+        public static SongInfo InfoFromID(string id)
+        {
+            Song song = FetchByID(id);
+            if (song == null)
+                return null;
+
+            SongInfo info = new SongInfo() { levelId = song.HashMD5.ToUpper(), songName = song.Name };
+            return info;
+        }
+
+        public static List<SongInfo> ConvertSongIDs(List<string> ids)
+        {
+            List<SongInfo> songs = ids.ConvertAll(id => InfoFromID(id));
+            return songs.Where(song => song != null).ToList();
+        }
+    }
+}

--- a/ServerHub/Misc/BeatSaver.cs
+++ b/ServerHub/Misc/BeatSaver.cs
@@ -51,7 +51,7 @@ namespace ServerHub.Misc
             if (song == null)
                 return null;
 
-            SongInfo info = new SongInfo() { levelId = song.HashMD5.ToUpper(), songName = song.Name };
+            SongInfo info = new SongInfo() { levelId = song.HashMD5.ToUpper(), songName = "" };
             return info;
         }
 

--- a/ServerHub/Misc/Settings.cs
+++ b/ServerHub/Misc/Settings.cs
@@ -184,6 +184,7 @@ namespace ServerHub.Misc {
         {
             private bool _enabled;
             private int _rooms;
+            private string _password;
             private List<string> _songHashes;
 
             private Action MarkDirty { get; }
@@ -220,6 +221,20 @@ namespace ServerHub.Misc {
             /// Remember to Save after changing the value
             /// </summary>
             [JsonProperty]
+            public string Password
+            {
+                get => _password;
+                set
+                {
+                    _password = value;
+                    MarkDirty();
+                }
+            }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
             public List<string> SongHashes
             {
                 get => _songHashes;
@@ -235,6 +250,7 @@ namespace ServerHub.Misc {
                 MarkDirty = markDirty;
                 _enabled = false;
                 _rooms = 4;
+                _password = "";
                 _songHashes = new List<string>();
             }
         }

--- a/ServerHub/Misc/Settings.cs
+++ b/ServerHub/Misc/Settings.cs
@@ -185,7 +185,7 @@ namespace ServerHub.Misc {
             private bool _enabled;
             private int _rooms;
             private string _password;
-            private List<string> _songHashes;
+            private List<string> _songIDs;
 
             private Action MarkDirty { get; }
 
@@ -235,12 +235,12 @@ namespace ServerHub.Misc {
             /// Remember to Save after changing the value
             /// </summary>
             [JsonProperty]
-            public List<string> SongHashes
+            public List<string> SongIDs
             {
-                get => _songHashes;
+                get => _songIDs;
                 set
                 {
-                    _songHashes = value;
+                    _songIDs = value;
                     MarkDirty();
                 }
             }
@@ -251,7 +251,7 @@ namespace ServerHub.Misc {
                 _enabled = false;
                 _rooms = 4;
                 _password = "";
-                _songHashes = new List<string>();
+                _songIDs = new List<string>();
             }
         }
 

--- a/ServerHub/Misc/Settings.cs
+++ b/ServerHub/Misc/Settings.cs
@@ -100,6 +100,7 @@ namespace ServerHub.Misc {
                 _webSocketPort = 3701;
             }
         }
+
         [JsonObject(MemberSerialization.OptIn)]
         public class LoggerSettings {
             private string _logsDir;
@@ -178,12 +179,74 @@ namespace ServerHub.Misc {
 
         }
 
+        [JsonObject(MemberSerialization.OptIn)]
+        public class TournamentModeSettings
+        {
+            private bool _enabled;
+            private int _rooms;
+            private List<string> _songHashes;
+
+            private Action MarkDirty { get; }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
+            public bool Enabled
+            {
+                get => _enabled;
+                set
+                {
+                    _enabled = value;
+                    MarkDirty();
+                }
+            }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
+            public int Rooms
+            {
+                get => _rooms;
+                set
+                {
+                    _rooms = value;
+                    MarkDirty();
+                }
+            }
+
+            /// <summary>
+            /// Remember to Save after changing the value
+            /// </summary>
+            [JsonProperty]
+            public List<string> SongHashes
+            {
+                get => _songHashes;
+                set
+                {
+                    _songHashes = value;
+                    MarkDirty();
+                }
+            }
+
+            public TournamentModeSettings(Action markDirty)
+            {
+                MarkDirty = markDirty;
+                _enabled = false;
+                _rooms = 4;
+                _songHashes = new List<string>();
+            }
+        }
+
         [JsonProperty]
         public ServerSettings Server { get; }
         [JsonProperty]
         public LoggerSettings Logger { get; }
         [JsonProperty]
         public AccessSettings Access { get; }
+        [JsonProperty]
+        public TournamentModeSettings TournamentMode { get; }
 
         private static Settings _instance;
 
@@ -213,6 +276,7 @@ namespace ServerHub.Misc {
             Server = new ServerSettings(MarkDirty);
             Logger = new LoggerSettings(MarkDirty);
             Access = new AccessSettings(MarkDirty);
+            TournamentMode = new TournamentModeSettings(MarkDirty);
             MarkDirty();
         }
 

--- a/ServerHub/Rooms/Room.cs
+++ b/ServerHub/Rooms/Room.cs
@@ -84,12 +84,12 @@ namespace ServerHub.Rooms
             if (roomClients.Count > 0)
             {
                 if(player.playerInfo.Equals(roomHost))
-                    TransferHost(player.playerInfo, roomClients.Random().playerInfo);
+                        TransferHost(player.playerInfo, roomClients.Random().playerInfo);
             }
             else
             {
                 if (!Settings.Instance.TournamentMode.Enabled)
-                DestroyRoom(player.playerInfo);
+                    DestroyRoom(player.playerInfo);
             }
         }
 
@@ -359,6 +359,12 @@ namespace ServerHub.Rooms
             {
                 Logger.Instance.Warning($"{sender.playerName}:{sender.playerId} tried to transfer host, but he is not the host");
             }
+        }
+
+        public void ForceTransferHost(PlayerInfo newHost)
+        {
+            roomHost = newHost;
+            BroadcastPacket(new BasePacket(CommandType.TransferHost, roomHost.ToBytes(false)));
         }
 
         struct ReadyPlayers

--- a/ServerHub/Rooms/Room.cs
+++ b/ServerHub/Rooms/Room.cs
@@ -88,6 +88,7 @@ namespace ServerHub.Rooms
             }
             else
             {
+                if (!Settings.Instance.TournamentMode.Enabled)
                 DestroyRoom(player.playerInfo);
             }
         }

--- a/ServerHub/Rooms/RoomsController.cs
+++ b/ServerHub/Rooms/RoomsController.cs
@@ -83,7 +83,7 @@ namespace ServerHub.Rooms
                                     room.roomClients.Remove(loggedIn);
                                 }
                             }
-                            room.roomClients.Add(client);
+                            AddClient(room, client);
                             return true;
                         }
                         else
@@ -97,7 +97,7 @@ namespace ServerHub.Rooms
                     {
                         client.SendData(new BasePacket(CommandType.JoinRoom, new byte[1] { (byte)JoinResult.Success }));
                         client.joinedRoomID = room.roomId;
-                        room.roomClients.Add(client);
+                        AddClient(room, client);
                         return true;
                     }
                 }
@@ -113,6 +113,14 @@ namespace ServerHub.Rooms
                 return false;
             }
         } 
+
+        public static void AddClient(Room room, Client client)
+        {
+            if (room.GetRoomInfo().players == 0 && Settings.Instance.TournamentMode.Enabled)
+                room.ForceTransferHost(client.playerInfo);
+
+            room.roomClients.Add(client);
+        }
 
         public static void ClientLeftRoom(Client client)
         {


### PR DESCRIPTION
Tournament Mode allows a ServerHub operator to switch from normal usage cases to a system similar to how the legacy 0.4.x.x release line worked.

## Config
Tournament Mode has its own section in the config. *(Remove the comments if copy/pasting this example, they are invalid in JSON)*
```json5
"TournamentMode": {
  // Enables or disables tournament mode
  "Enabled": true,
  // Specifies the number of rooms to create on startup. Defaults to 4
  "Rooms": 4,
  // Allows you to lock the pre-made rooms. Leave blank for no password.
  "Password": "",
  // A list of BeatSaver IDs. Each pre-made room will have only these songs enabled.
  "SongIDs": [
    "65-33",
    "967-650"
  ]
}
```

## New Features
### Persistent Rooms
When the hub launches, it creates rooms automatically with the names "Tournament Room X" where X is a number. These rooms **(and any rooms creates manually)** will behave a little differently to normal rooms.
* After enabling tournament mode, rooms will no longer be automatically destroyed when all clients leave. 
* Room host will be transferred to the first client to join an empty room. This applies even if there have been clients in the room before.

### Song Pre-loading
To ensure players can only pick from any map pool you might have in place, you can configure the pre-made rooms to come loaded with songs already.
The rooms are in manual mode so the host will also be able to select the difficulty.