### PR TITLE
Let docker expose 3700/udp, not 3700/tcp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ COPY --from=builder /app/ServerHub/out .
 
 # Start the process
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=1 CMD nc -w 5 -uvz localhost 3700
-EXPOSE 3700
+EXPOSE 3700/udp
 CMD ["./ServerHub"]


### PR DESCRIPTION
Since the server switched to a UDP connection the container should expose the matching port.
According to the docker docs:
> By default, `EXPOSE` assumes TCP.

Are you okay with that @lolPants? 