### PR TITLE
Get the localPlayerIndex after sorting by score.

### DIFF
--- a/BeatSaberMultiplayer/InGameOnlineController.cs
+++ b/BeatSaberMultiplayer/InGameOnlineController.cs
@@ -347,13 +347,11 @@ namespace BeatSaberMultiplayer
                         {
                             Console.WriteLine($"PlayerControllers exception: {e}");
                         }
-
-                        localPlayerIndex = playerInfos.FindIndexInList(Client.Instance.playerInfo);
-
+                        
                         if (_currentScene == "GameCore" && loaded)
                         {
                             playerInfos = playerInfos.OrderByDescending(x => x.playerScore).ToList();
-
+                            localPlayerIndex = playerInfos.FindIndexInList(Client.Instance.playerInfo);
                             if (_scoreDisplays.Count < 5)
                             {
                                 _scoreScreen = new GameObject("ScoreScreen");


### PR DESCRIPTION
I noticed a bug in multiplayer matches with more than 5 people where it wouldn't always show your own score. I haven't actually been able to test this in a game, but it worked in a simple test project.