### PR TITLE
Bailoutmode

### DIFF
--- a/BeatSaberMultiplayer/BailOutController.cs
+++ b/BeatSaberMultiplayer/BailOutController.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+using TMPro;
+
+namespace BeatSaberMultiplayer
+{
+    class BailOutController : MonoBehaviour
+    {
+        #region "Fields with get/setters"
+        private static BailOutController _instance;
+        private LevelFailedTextEffect _levelFailedEffect;
+        private StandardLevelGameplayManager _gameManager;
+        private GameEnergyCounter _energyCounter;
+        private TextMeshProUGUI _failText;
+        private PlayerSpecificSettings _playerSettings;
+        private StandardLevelSceneSetup _standardLevelSceneSetup;
+        #endregion
+        #region "Fields"
+        public bool isHiding = false;
+        public static int numFails = 0;
+
+        #region Settings
+        
+        public static bool BailOutEnabled = false;  // Is BailOutMode enabled
+        public static int EnergyResetAmount = 50; // Amount of energy to reset to on failure
+        public static bool ShowFailEffect = true; // Whether to show the giant Failed effect on failure
+        public static int FailEffectDuration = 2; // How long the Failed effect remains on screen (seconds)
+        public static bool ShowFailText = true; // Whether to show the Bailed out text
+        public static string FailTextPosition = "0,.3,2.5"; // Position of the Bailed out text
+        public static float FailTextFontSize = 20f; // Font size for the Bailed out text
+        #endregion
+        public TextMeshProUGUI FailText
+        {
+            get
+            {
+                if (_failText == null)
+                    _failText = CreateFailText("");
+                return _failText;
+            }
+            set { _failText = value; }
+        }
+
+        private LevelFailedTextEffect LevelFailedEffect
+        {
+            get
+            {
+                if (_levelFailedEffect == null)
+                    _levelFailedEffect = GameObject.FindObjectsOfType<LevelFailedTextEffect>().FirstOrDefault();
+                return _levelFailedEffect;
+            }
+            set { _levelFailedEffect = value; }
+        }
+        private StandardLevelGameplayManager GameManager
+        {
+            get
+            {
+                if (_gameManager == null)
+                    _gameManager = GameObject.FindObjectsOfType<StandardLevelGameplayManager>().FirstOrDefault();
+                return _gameManager;
+            }
+        }
+
+        private StandardLevelSceneSetup standardLevelSceneSetup
+        {
+            get
+            {
+                if (_standardLevelSceneSetup == null)
+                    _standardLevelSceneSetup = GameObject.FindObjectsOfType<StandardLevelSceneSetup>().FirstOrDefault();
+                return _standardLevelSceneSetup;
+            }
+        }
+        private GameEnergyCounter EnergyCounter
+        {
+            get
+            {
+                if (_energyCounter == null)
+                    _energyCounter = GameObject.FindObjectsOfType<GameEnergyCounter>().FirstOrDefault();
+                return _energyCounter;
+            }
+        }
+        private PlayerSpecificSettings PlayerSettings
+        {
+            get
+            {
+                if (_playerSettings == null)
+                    _playerSettings = standardLevelSceneSetup?.standardLevelSceneSetupData?.gameplayCoreSetupData?.playerSpecificSettings;
+                return _playerSettings;
+            }
+        }
+        private float PlayerHeight;
+        public static BailOutController Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new GameObject("BailOutController").AddComponent<BailOutController>();
+                }
+                return _instance;
+            }
+        }
+        public static bool InstanceExists
+        {
+            get { return _instance != null; }
+        }
+
+        #endregion
+
+        public void Awake()
+        {
+            _instance = this;
+            isHiding = false;
+        }
+
+        public void Start()
+        {
+            LevelFailedEffect = GameObject.FindObjectsOfType<LevelFailedTextEffect>().FirstOrDefault();
+            if ((GameManager != null) && (EnergyCounter != null) && BailOutEnabled)
+            {
+                EnergyCounter.gameEnergyDidReach0Event -= GameManager.HandleGameEnergyDidReach0;
+            }
+            if (PlayerSettings != null)
+                PlayerHeight = PlayerSettings.playerHeight;
+            else
+                PlayerHeight = 1.8f;
+        }
+
+        private void OnDestroy()
+        {
+        }
+
+
+        public void ShowLevelFailed()
+        {
+            BS_Utils.Gameplay.ScoreSubmission.DisableSubmission(Plugin.instance.Name);
+            if(ShowFailText)
+                FailText.text = $"Bailed Out {numFails} time{(numFails != 1 ? "s" : "")}";
+            if (!isHiding && ShowFailEffect)
+            {
+                try
+                {
+                    LevelFailedEffect.gameObject.SetActive(true);
+                    LevelFailedEffect.ShowEffect();
+                    if (FailEffectDuration > 0)
+                        StartCoroutine(hideLevelFailed());
+                    else
+                        isHiding = true; // Fail text never hides, so don't try to keep showing it
+                }
+                catch (Exception ex)
+                {
+                    Misc.Logger.Exception(ex);
+                }
+            }
+        }
+
+        public IEnumerator<WaitForSeconds> hideLevelFailed()
+        {
+            if (!isHiding)
+            {
+                isHiding = true;
+                yield return new WaitForSeconds(FailEffectDuration);
+                LevelFailedEffect.gameObject.SetActive(false);
+                isHiding = false;
+            }
+            yield break;
+        }
+
+        public static void FacePosition(Transform obj, Vector3 targetPos)
+        {
+            var rotAngle = Quaternion.LookRotation(obj.position - targetPos);
+            obj.rotation = rotAngle;
+        }
+
+        public TextMeshProUGUI CreateFailText(string text, float yOffset = 0)
+        {
+            var textGO = new GameObject();
+            textGO.transform.position = StringToVector3(FailTextPosition);
+            textGO.transform.eulerAngles = new Vector3(0f, 0f, 0f);
+            textGO.transform.localScale = new Vector3(0.01f, 0.01f, 0.01f);
+            var textCanvas = textGO.AddComponent<Canvas>();
+            textCanvas.renderMode = RenderMode.WorldSpace;
+            (textCanvas.transform as RectTransform).sizeDelta = new Vector2(200f, 50f);
+
+            FacePosition(textCanvas.transform, new Vector3(0, PlayerHeight, 0));
+            TextMeshProUGUI textMeshProUGUI = new GameObject("BailOutFailText").AddComponent<TextMeshProUGUI>();
+
+            RectTransform rectTransform = textMeshProUGUI.transform as RectTransform;
+            rectTransform.anchoredPosition = new Vector2(0f, 0f);
+            rectTransform.sizeDelta = new Vector2(400f, 20f);
+            rectTransform.Translate(new Vector3(0, yOffset, 0));
+            textMeshProUGUI.text = text;
+            textMeshProUGUI.fontSize = FailTextFontSize;
+            textMeshProUGUI.alignment = TextAlignmentOptions.Center;
+            textMeshProUGUI.ForceMeshUpdate();
+            textMeshProUGUI.rectTransform.SetParent(textCanvas.transform, false);
+            return textMeshProUGUI;
+        }
+
+        public static Vector3 StringToVector3(string vStr)
+        {
+            string[] sAry = vStr.Split(',');
+            try
+            {
+                Vector3 retVal = new Vector3(
+                    float.Parse(sAry[0]),
+                    float.Parse(sAry[1]),
+                    float.Parse(sAry[2]));
+                return retVal;
+            }
+            catch (Exception ex)
+            {
+                return new Vector3(0f, .3f, 2.5f);
+            }
+        }
+    }
+}

--- a/BeatSaberMultiplayer/BeatSaberMultiplayer.csproj
+++ b/BeatSaberMultiplayer/BeatSaberMultiplayer.csproj
@@ -67,6 +67,9 @@
     <Reference Include="SongLoaderPlugin">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\SongLoaderPlugin.dll</HintPath>
     </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\0Harmony.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -148,6 +151,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AvatarController.cs" />
+    <Compile Include="BailOutController.cs" />
     <Compile Include="Client.cs" />
     <Compile Include="Data\BeatSaverAPIResult.cs" />
     <Compile Include="Data\ChannelInfo.cs" />
@@ -178,6 +182,7 @@
     <Compile Include="OverriddenClasses\OnlineAudioTimeController.cs" />
     <Compile Include="OverriddenClasses\OnlineBeatmapCallbackController.cs" />
     <Compile Include="OverriddenClasses\OnlineBeatmapSpawnController.cs" />
+    <Compile Include="OverriddenClasses\OnlineEnergyCounter.cs" />
     <Compile Include="OverriddenClasses\OnlineVRController.cs" />
     <Compile Include="OnlinePlayerController.cs" />
     <Compile Include="PlayerInfoDisplay.cs" />

--- a/BeatSaberMultiplayer/Data/RoomInfo.cs
+++ b/BeatSaberMultiplayer/Data/RoomInfo.cs
@@ -8,6 +8,7 @@ namespace BeatSaberMultiplayer.Data
 {
     public enum RoomState: byte {SelectingSong, Preparing, InGame, Results }
     public enum SongSelectionType : byte { Manual,  Random }
+    public enum NoFailType : byte { Off, NoFail, Bailout }
 
     public class RoomInfo
     {
@@ -23,7 +24,16 @@ namespace BeatSaberMultiplayer.Data
         public int players;
         public int maxPlayers;
 
-        public bool noFail;
+        private NoFailType _noFail;
+        public NoFailType noFail
+        {
+            get { return _noFail; }
+            set
+            {
+                _noFail = value;
+                BailOutController.BailOutEnabled = (noFail == NoFailType.Bailout) ? true : false; // If noFail is set to Bailout, enable in BailOutController
+            }
+        }
 
         public byte selectedDifficulty;
         public SongInfo selectedSong;
@@ -39,7 +49,7 @@ namespace BeatSaberMultiplayer.Data
             roomId = msg.ReadUInt32();
             name = msg.ReadString();
             usePassword = msg.ReadBoolean();
-            noFail = msg.ReadBoolean();
+            noFail = (NoFailType) msg.ReadByte();
             msg.SkipPadBits();
             roomState = (RoomState)msg.ReadByte();
             songSelectionType = (SongSelectionType)msg.ReadByte();
@@ -71,7 +81,7 @@ namespace BeatSaberMultiplayer.Data
             msg.Write(roomId);
             msg.Write(name);
             msg.Write(usePassword);
-            msg.Write(noFail);
+            msg.Write((byte)noFail);
             msg.WritePadBits();
             msg.Write((byte)roomState);
             msg.Write((byte)songSelectionType);

--- a/BeatSaberMultiplayer/Data/RoomSettings.cs
+++ b/BeatSaberMultiplayer/Data/RoomSettings.cs
@@ -16,7 +16,7 @@ namespace BeatSaberMultiplayer.Data
 
         public SongSelectionType SelectionType;
         public int MaxPlayers;
-        public bool NoFail;
+        public NoFailType NoFail;
         
         public RoomSettings()
         {
@@ -30,7 +30,7 @@ namespace BeatSaberMultiplayer.Data
             Password = node["Password"];
             SelectionType = (SongSelectionType)node["SelectionType"].AsInt;
             MaxPlayers = node["MaxPlayers"];
-            NoFail = node["NoFail"];
+            NoFail = (NoFailType)node["NoFail"].AsInt;
         }
         
         public RoomSettings(NetIncomingMessage msg)
@@ -39,7 +39,7 @@ namespace BeatSaberMultiplayer.Data
             Name = msg.ReadString();
 
             UsePassword = msg.ReadBoolean();
-            NoFail = msg.ReadBoolean();
+            NoFail = (NoFailType)msg.ReadByte();
 
             msg.SkipPadBits();
 
@@ -56,7 +56,7 @@ namespace BeatSaberMultiplayer.Data
             msg.Write(Name);
 
             msg.Write(UsePassword);
-            msg.Write(NoFail);
+            msg.Write((byte)NoFail);
 
             msg.WritePadBits();
 

--- a/BeatSaberMultiplayer/OverriddenClasses/OnlineEnergyCounter.cs
+++ b/BeatSaberMultiplayer/OverriddenClasses/OnlineEnergyCounter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Harmony;
+using BS_Utils;
+
+namespace BeatSaberMultiplayer.OverriddenClasses
+{
+    [HarmonyPatch(typeof(GameEnergyCounter), "AddEnergy",
+        new Type[] {
+        typeof(float)})]
+    class OnlineEnergyCounter
+    {
+        static bool Prefix(GameEnergyCounter __instance, ref float value)
+        {
+            if (BailOutController.BailOutEnabled && value < 0f)
+            {
+                if (__instance.energy + value <= 0)
+                {
+                    if(BailOutController.numFails == 0)
+                        Misc.Logger.Info("Score submission disabled by BailOutMode");
+                    BS_Utils.Gameplay.ScoreSubmission.DisableSubmission(Plugin.instance.Name);
+                    BailOutController.numFails++;
+                    value = (BailOutController.EnergyResetAmount / 100f) - __instance.energy;
+                    BailOutController.Instance.ShowLevelFailed();
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/BeatSaberMultiplayer/UI/FlowCoordinators/RoomFlowCoordinator.cs
+++ b/BeatSaberMultiplayer/UI/FlowCoordinators/RoomFlowCoordinator.cs
@@ -534,7 +534,7 @@ namespace BeatSaberMultiplayer.UI.FlowCoordinators
                 else
                 {
                     Client.Instance.playerInfo.playerState = PlayerState.Game;
-                    gameplayModifiers.noFail = roomInfo.noFail;
+                    gameplayModifiers.noFail = (roomInfo.noFail == NoFailType.NoFail) ? true : false; // 
                 }
 
                 PlayerSpecificSettings playerSettings = Resources.FindObjectsOfTypeAll<PlayerDataModelSO>().FirstOrDefault().currentLocalPlayer.playerSpecificSettings;

--- a/BeatSaberMultiplayer/UI/ViewControllers/CreateRoomScreen/MainRoomCreationViewController.cs
+++ b/BeatSaberMultiplayer/UI/ViewControllers/CreateRoomScreen/MainRoomCreationViewController.cs
@@ -29,7 +29,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
         private OnOffViewController _usePasswordToggle;
         private MultiplayerListViewController _songSelectionList;
         private MultiplayerListViewController _maxPlayersList;
-        private OnOffViewController _noFailToggle;
+        private MultiplayerListViewController _noFailList;
         private TextMeshProUGUI _nameText;
         private TextMeshProUGUI _passwordText;
 
@@ -48,7 +48,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
         private SongSelectionType _songSelectionType;
         private int _maxPlayers = 0;
         private bool _usePassword = false;
-        private bool _noFailMode = true;
+        private NoFailType _noFailMode = 0;
 
         protected override void DidActivate(bool firstActivation, ActivationType activationType)
         {
@@ -83,9 +83,11 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
                 _maxPlayersList.Value = _maxPlayers;
                 _maxPlayersList.maxValue = 16;
 
-                _noFailToggle = CustomSettingsHelper.AddToggleSetting<OnOffViewController>(rectTransform, "No Fail Mode", new Vector2(0f, -20f));
-                _noFailToggle.ValueChanged += NoFailToggle_ValueChanged;
-                _noFailToggle.Value = _noFailMode;
+                _noFailList = CustomSettingsHelper.AddListSetting<MultiplayerListViewController>(rectTransform, "No Fail Mode", new Vector2(0f, -20f));
+                _noFailList.textForValues = new string[] { "Off", "No-Fail", "Bailout" };
+                _noFailList.ValueChanged += NoFail_ValueChanged;
+                _noFailList.Value = (int)_noFailMode;
+                _noFailList.maxValue = 2;
 
                 _roomName = $"{GetUserInfo.GetUserName()}'s room".ToUpper();
                 _nameText = BeatSaberUI.CreateText(rectTransform, _roomName, new Vector2(-22.5f, 25f));
@@ -165,7 +167,7 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
             _roomPassword = settings.Password;
 
             _noFailMode = settings.NoFail;
-            _noFailToggle.Value = _noFailMode;
+            _noFailList.Value = (int)_noFailMode;
 
             _maxPlayers = settings.MaxPlayers;
             _maxPlayersList.Value = _maxPlayers;
@@ -215,9 +217,9 @@ namespace BeatSaberMultiplayer.UI.ViewControllers.CreateRoomScreen
 
         }
 
-        private void NoFailToggle_ValueChanged(bool value)
+        private void NoFail_ValueChanged(int obj)
         {
-            _noFailMode = value;
+            _noFailMode = (NoFailType) obj;
         }
 
         private void UsePasswordToggle_ValueChanged(bool value)

--- a/BeatSaberMultiplayer/UI/ViewControllers/ServerHubScreen/RoomListViewController.cs
+++ b/BeatSaberMultiplayer/UI/ViewControllers/ServerHubScreen/RoomListViewController.cs
@@ -171,7 +171,8 @@ namespace BeatSaberMultiplayer.UI.ViewControllers
                 cell.GetComponentsInChildren<UnityEngine.UI.Image>(true).First(x => x.name == "CoverImage").enabled = false;
             }
             cell.songName = $"({room.players}/{((room.maxPlayers == 0)? "INF":room.maxPlayers.ToString())})" + room.name;
-            cell.author = $"{room.roomState.ToString()}{(room.noFail ? ", No Fail" : "")}";
+            string noFailString = (room.noFail == NoFailType.Off) ? "" : $", {room.noFail.ToString()}";
+            cell.author = $"{room.roomState.ToString()}{noFailString}";
 
             return cell;
         }

--- a/ServerHub/Data/RoomInfo.cs
+++ b/ServerHub/Data/RoomInfo.cs
@@ -10,6 +10,7 @@ namespace ServerHub.Data
 {
     public enum RoomState: byte {SelectingSong, Preparing, InGame, Results }
     public enum SongSelectionType : byte { Manual,  Random }
+    public enum NoFailType : byte { Off, NoFail, Bailout }
 
     public class RoomInfo
     {
@@ -27,7 +28,8 @@ namespace ServerHub.Data
         public int players;
         public int maxPlayers;
 
-        public bool noFail;
+        [JsonConverter(typeof(StringEnumConverter))]
+        public NoFailType noFail;
 
         public byte selectedDifficulty;
         public SongInfo selectedSong;
@@ -43,7 +45,7 @@ namespace ServerHub.Data
             roomId = msg.ReadUInt32();
             name = msg.ReadString();
             usePassword = msg.ReadBoolean();
-            noFail = msg.ReadBoolean();
+            noFail = (NoFailType)msg.ReadByte();
             msg.SkipPadBits();
             roomState = (RoomState)msg.ReadByte();
             songSelectionType = (SongSelectionType)msg.ReadByte();
@@ -76,7 +78,7 @@ namespace ServerHub.Data
             msg.Write(roomId);
             msg.Write(name);
             msg.Write(usePassword);
-            msg.Write(noFail);
+            msg.Write((byte)noFail);
             msg.WritePadBits();
             msg.Write((byte)roomState);
             msg.Write((byte)songSelectionType);

--- a/ServerHub/Data/RoomSettings.cs
+++ b/ServerHub/Data/RoomSettings.cs
@@ -15,7 +15,7 @@ namespace ServerHub.Data
 
         public SongSelectionType SelectionType;
         public int MaxPlayers;
-        public bool NoFail;
+        public NoFailType NoFail;
 
         public RoomSettings()
         {
@@ -28,7 +28,7 @@ namespace ServerHub.Data
             Name = msg.ReadString();
 
             UsePassword = msg.ReadBoolean();
-            NoFail = msg.ReadBoolean();
+            NoFail = (NoFailType) msg.ReadByte();
 
             msg.SkipPadBits();
 
@@ -44,7 +44,7 @@ namespace ServerHub.Data
             msg.Write(Name);
 
             msg.Write(UsePassword);
-            msg.Write(NoFail);
+            msg.Write((byte)NoFail);
 
             msg.WritePadBits();
 

--- a/ServerHub/Hub/Program.cs
+++ b/ServerHub/Hub/Program.cs
@@ -310,7 +310,7 @@ namespace ServerHub.Hub
                     Name = string.Format(Settings.Instance.TournamentMode.RoomNameTemplate, i + 1),
                     UsePassword = Settings.Instance.TournamentMode.Password != "",
                     Password = Settings.Instance.TournamentMode.Password,
-                    NoFail = true,
+                    NoFail = NoFailType.Off,
                     MaxPlayers = 0,
                     SelectionType = SongSelectionType.Manual
                 };


### PR DESCRIPTION
I thought scores still submitted in multiplayer for some reason...but I still like this better than no-fail mode anyway since I can see if I would've failed. Pretty much just pulled the whole thing from my standalone BailOutMode for this. It won't work with the previous ServerHubs because of the type change. There are static variables for the settings in BailOutController (if you didn't want to leave them hard-coded) along with a counter for the number of fails. It adds Harmony as a dependency.