### PR TITLE
Add two ServerHubs to default config

### DIFF
--- a/BeatSaberMultiplayer/Misc/Config.cs
+++ b/BeatSaberMultiplayer/Misc/Config.cs
@@ -44,7 +44,7 @@ namespace BeatSaberMultiplayer
             },
             {
                 "0.7.0.0",
-                new string[] { "bs.tigersserver.xyz" }
+                new string[] { "bs.tigersserver.xyz", "bbbear-wgzeyu.gtxcn.com", "bs-zhm.tk" }
             }
         };
 


### PR DESCRIPTION
At present, these ServerHubs are almost all running in Europe and North America, and the latency from Asia is very high. At the same time, due to the long-term congestion of international Internet exports in China, connecting these ServerHubs in China is very unstable.
So my friends and I have set up ServerHub in China and plan to run it for a long time, so I added it to the default configuration to optimize the online experience in China and even Asia.
I have contacted Assistant and these servers have been added to Guide.

server:
bbbear-wgzeyu.gtxcn.com:3700
bs-zhm.tk:3700

landing page:
https://bbbear-wgzeyu.gtxcn.com/
https://ws.bs-zhm.tk/