### PR TITLE
Server repositories added

### DIFF
--- a/BeatSaberMultiplayer/BeatSaberMultiplayer.csproj
+++ b/BeatSaberMultiplayer/BeatSaberMultiplayer.csproj
@@ -39,6 +39,7 @@
     <Compile Include="Data\RoomInfo.cs" />
     <Compile Include="Data\RoomPreset.cs" />
     <Compile Include="Data\RoomSettings.cs" />
+    <Compile Include="Data\ServerRepository.cs" />
     <Compile Include="Data\SongInfo.cs" />
     <Compile Include="Data\LevelOptionsInfo.cs" />
     <Compile Include="InGameOnlineController.cs" />

--- a/BeatSaberMultiplayer/Data/ServerRepository.cs
+++ b/BeatSaberMultiplayer/Data/ServerRepository.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+
+using System.Globalization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BeatSaberMultiplayer.Data
+{
+    public partial class ServerRepository
+    {
+        [JsonProperty("RepositoryName")]
+        public string RepositoryName { get; set; }
+
+        [JsonProperty("RepositoryDescription", NullValueHandling = NullValueHandling.Ignore)]
+        public string RepositoryDescription { get; set; }
+
+        [JsonProperty("Servers")]
+        public List<RepositoryServer> Servers { get; set; }
+
+        public override string ToString()
+        {
+            return $"{RepositoryName}: {Servers.Count} servers";
+        }
+    }
+
+    public partial class RepositoryServer
+    {
+        [JsonProperty("ServerName", NullValueHandling = NullValueHandling.Ignore)]
+        public string ServerName { get; set; }
+
+        [JsonProperty("ServerAddress")]
+        public string ServerAddress { get; set; }
+
+        [JsonProperty("ServerPort")]
+        public int ServerPort { get; set; }
+
+        public bool IsValid
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(ServerAddress))
+                    return false;
+                if (ServerPort < 1 || ServerPort > 65535)
+                    return false;
+                return true;
+            }
+        }
+
+        public override string ToString()
+        {
+            string retStr = string.Empty;
+            if (!string.IsNullOrEmpty(ServerName))
+                retStr = ServerName + " | ";
+            if (!string.IsNullOrEmpty(ServerAddress))
+                retStr = retStr + ServerAddress + ":" + ServerPort;
+            else
+                retStr = retStr + "<NULL>:" + ServerPort;
+            return retStr;
+        }
+    }
+
+    public partial class ServerRepository
+    {
+        public static ServerRepository FromJson(string json) => JsonConvert.DeserializeObject<ServerRepository>(json, BeatSaberMultiplayer.Data.Converter.Settings);
+    }
+
+    public static class Serialize
+    {
+        public static string ToJson(this ServerRepository self) => JsonConvert.SerializeObject(self, BeatSaberMultiplayer.Data.Converter.Settings);
+    }
+
+    internal static class Converter
+    {
+        public static readonly JsonSerializerSettings Settings = new JsonSerializerSettings
+        {
+            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+            DateParseHandling = DateParseHandling.None,
+            //Converters =
+            //{
+            //    new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
+            //},
+        };
+    }
+}

--- a/BeatSaberMultiplayer/Misc/Config.cs
+++ b/BeatSaberMultiplayer/Misc/Config.cs
@@ -11,6 +11,7 @@ namespace BeatSaberMultiplayer
     public class Config {
 
         [SerializeField] private string _modVersion;
+        [SerializeField] private string[] _serverRepositories;
         [SerializeField] private string[] _serverHubIPs;
         [SerializeField] private int[] _serverHubPorts;
         [SerializeField] private bool _showAvatarsInGame;
@@ -50,6 +51,11 @@ namespace BeatSaberMultiplayer
                 "0.7.0.0",
                 new string[] { "bs.tigersserver.xyz", "bbbear-wgzeyu.gtxcn.com", "bs-zhm.tk", "pantie.xicp.net" }
             }
+        };
+
+        private static readonly List<string> newServerRepositories = new List<string>()
+        {
+            "https://raw.githubusercontent.com/Zingabopp/BeatSaberMultiplayerServerRepo/master/CompatibleServers.json"
         };
 
         public static bool Load()
@@ -118,6 +124,18 @@ namespace BeatSaberMultiplayer
                     _instance.ServerHubPorts = _instance.ServerHubPorts.Concat(Enumerable.Repeat(3700, hubs.Count)).ToArray();
 
                     Plugin.log.Info($"Added {hubs.Count} new ServerHubs to config!");
+
+                    List<string> repos = new List<string>();
+                    if (_instance._serverRepositories.Length != 0)
+                    {
+                        repos.AddRange(_instance._serverRepositories);
+                    }
+                    foreach (var newRepo in newServerRepositories)
+                    {
+                        Plugin.log.Warn($"Adding repo: {newRepo}");
+                        repos.Add(newRepo);
+                    }
+                    _instance.ServerRepositories = repos.ToArray();
                 }
             }
             _instance.ModVersion = IPA.Loader.PluginManager.GetPluginFromId("BeatSaberMultiplayer").Metadata.Version.ToString();
@@ -148,10 +166,20 @@ namespace BeatSaberMultiplayer
                 MarkDirty();
             }
         }
-        
+
+        public string[] ServerRepositories
+        {
+            get { return _serverRepositories; }
+            set
+            {
+                _serverRepositories = value;
+                MarkDirty();
+            }
+        }
+
         /// <summary>
-         /// Remember to Save after changing the value
-         /// </summary>
+        /// Remember to Save after changing the value
+        /// </summary>
         public string[] ServerHubIPs
         {
             get { return _serverHubIPs; }
@@ -372,6 +400,7 @@ namespace BeatSaberMultiplayer
         Config()
         {
             _modVersion = string.Empty;
+            _serverRepositories = new string[0];
             _serverHubIPs = new string[0];
             _serverHubPorts = new int[0];
             _showAvatarsInGame = false;


### PR DESCRIPTION
* Adds Server Repositories
  * Server Repositories are jsons that provide a list of ServerHubs.
  * Users can add server repositories to their configs that Multiplayer will read from when the ServerHubFlowCoordinator is activated and add those ServerHubs to its list of monitored servers. 

I copied what I did in MultiplayerLite over, but haven't tested it on this branch. The repo with the json schema and two Server Repositories can be found [Here](https://github.com/Zingabopp/BeatSaberMultiplayerServerRepo). I'm open to any changes you want to make to the schema.