### PR TITLE
Changed default ServerRepo URL to use github.io

### DIFF
--- a/BeatSaberMultiplayer/Misc/Config.cs
+++ b/BeatSaberMultiplayer/Misc/Config.cs
@@ -345,7 +345,7 @@ namespace BeatSaberMultiplayer
         Config()
         {
             _modVersion = string.Empty;
-            _serverRepositories = new string[1] { "https://raw.githubusercontent.com/Zingabopp/BeatSaberMultiplayerServerRepo/master/CompatibleServers.json" };
+            _serverRepositories = new string[1] { "https://zingabopp.github.io/BeatSaberMultiplayerServerRepo/CompatibleServers.json" };
             _serverHubIPs = new string[0];
             _serverHubPorts = new int[0];
             _showAvatarsInGame = false;


### PR DESCRIPTION
raw.githubusercontent.com doesn't seem to work well in China (and maybe other places?). I enabled GitHub pages on the server repository repo.